### PR TITLE
3 fixes

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -1,9 +1,9 @@
 [entity-name]
-rrm-range10-building = R10 Resource Relocation Machine
-rrm-range20-building = R20 Resource Relocation Machine
-rrm-range30-building = R30 Resource Relocation Machine
+rrm-range10-building= R10 Resource Relocation Machine
+rrm-range20-building= R20 Resource Relocation Machine
+rrm-range30-building= R30 Resource Relocation Machine
 
 [entity-description]
-rrm-range10-building = Moves ore resources from 10 tiles away to its front side.
-rrm-range20-building = Moves ore resources from 20 tiles away to its front side.
-rrm-range30-building = Moves ore resources from 30 tiles away to its front side.
+rrm-range10-building= Moves ore resources from 10 tiles away to its front side.
+rrm-range20-building= Moves ore resources from 20 tiles away to its front side.
+rrm-range30-building= Moves ore resources from 30 tiles away to its front side.

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -7,7 +7,7 @@ function make_rrm(inputs)
     temp.name = "rrm-range" .. inputs.range .. "-building"
     temp.icon = "__Resource_Relocation_Machines__/graphics/Range" .. inputs.range .. "-Icon.png"
     temp.icon_size = 32
-    temp.minable = {hardness = 0.1, mining_time = 0.1, result = "rrm-range10"}
+    temp.minable = {hardness = 0.1, mining_time = 0.1, result = "rrm-range" .. inputs.range}
     temp.max_health = 50
     temp.item_slot_count = 1
     temp.sprites =

--- a/prototypes/recipe.lua
+++ b/prototypes/recipe.lua
@@ -4,7 +4,7 @@ data:extend({
 	{
     type = "recipe",
     name = "rrm-range10",
-    enabled = "true",
+    enabled = true,
     ingredients = 
     {
       {"iron-gear-wheel", 5},
@@ -18,7 +18,7 @@ data:extend({
     {
     type = "recipe",
     name = "rrm-range20",
-    enabled = "true",
+    enabled = true,
     ingredients = 
     {
       {"rrm-range10",1},
@@ -30,7 +30,7 @@ data:extend({
     {
     type = "recipe",
     name = "rrm-range30",
-    enabled = "true",
+    enabled = true,
     ingredients = 
     {
       {"rrm-range20",1},


### PR DESCRIPTION
1. Fix the recipes not showing up to the player / requiring a console command to spawn them. Note: The items show up in the 'unordered' tab. This if fixable as well by adding a 'order = "string"' field to the item description.
2. Fix locale strings so they display in game. (you can't have a space before the =. yay whitespace languages! >.<)
3. Fix mining resulting in a lower level item being returned.

I didn't bump the version in info.json. I didn't know what convention/scripts you might use, so that will need to be updated before you publish. Other than that, this should be a painless merge->publish.